### PR TITLE
Introduced option to control schema drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,25 +322,30 @@ Default template file:
   },
   "Ingestion": {
     "Parallelism": 1
+  },
+  "SchemaHandling": {
+    "EnableSchemaUpgradeForExistingTables": true
   }
+
 }
 ```
 
-| Section              | Setting        | Description                                                                          |
-|----------------------|----------------|--------------------------------------------------------------------------------------|
-| DataverseStorage     | StorageAccount | FQDN of the storage account containing Dataverse data.                               |
-| DataverseStorage     | Container      | Storage container containing Dataverse data (created by Synapse Link for Dataverse). |
-| IncrementalStorage   | StorageAccount | FQDN of the storage account containing incremental data.                             |
-| IncrementalStorage   | Container      | Storage container containing incremental data.                                       |
-| ConfigurationStorage | StorageAccount | FQDN of the storage account containing DataverseToSql configuration data.            |
-| ConfigurationStorage | Container      | Storage container containing DataverseToSql configuration data.                      |
-| Database             | Server         | FQDN of the Azure SQL Database.                                                      |
-| Database             | Database       | Name of the Azure SQL Database.                                                      |
-| Database             | Schema         | SQL Schema to be used for Dataverse tables.                                          |
-| SynapseWorkspace     | SubscriptionId | Subscription ID of the Synapse workspace.                                            |
-| SynapseWorkspace     | ResourceGroup  | Resource group of the Synapse workspace.                                             |
-| SynapseWorkspace     | Workspace      | Name of the Synapse workspace.                                                       |
-| Ingestion            | Parallelism    | Number of concurrent copy activities performed by the ingestion pipeline.            |
+| Section              | Setting                              | Default | Description                                                                          |
+|----------------------|--------------------------------------|---------|--------------------------------------------------------------------------------------|
+| DataverseStorage     | StorageAccount                       |         | FQDN of the storage account containing Dataverse data.                               |
+| DataverseStorage     | Container                            |         | Storage container containing Dataverse data (created by Synapse Link for Dataverse). |
+| IncrementalStorage   | StorageAccount                       |         | FQDN of the storage account containing incremental data.                             |
+| IncrementalStorage   | Container                            |         | Storage container containing incremental data.                                       |
+| ConfigurationStorage | StorageAccount                       |         | FQDN of the storage account containing DataverseToSql configuration data.            |
+| ConfigurationStorage | Container                            |         | Storage container containing DataverseToSql configuration data.                      |
+| Database             | Server                               |         | FQDN of the Azure SQL Database.                                                      |
+| Database             | Database                             |         | Name of the Azure SQL Database.                                                      |
+| Database             | Schema                               |         | SQL Schema to be used for Dataverse tables.                                          |
+| SynapseWorkspace     | SubscriptionId                       |         | Subscription ID of the Synapse workspace.                                            |
+| SynapseWorkspace     | ResourceGroup                        |         | Resource group of the Synapse workspace.                                             |
+| SynapseWorkspace     | Workspace                            |         | Name of the Synapse workspace.                                                       |
+| Ingestion            | Parallelism                          | 1       | Number of concurrent copy activities performed by the ingestion pipeline.            |
+| SchemaHandling       | EnableSchemaUpgradeForExistingTables | true    | Enable the propagation of schema changes for existing tables.                        |
 
 ### Provide scripts for custom SQL objects
 

--- a/src/DataverseToSql/DataverseToSql.Core/EnvironmentBase.cs
+++ b/src/DataverseToSql/DataverseToSql.Core/EnvironmentBase.cs
@@ -86,7 +86,7 @@ namespace DataverseToSql.Core
         // Initialize the dictionary of CDM entities.
         // The dictionary contains only entities with
         // "Completed" InitialSyncState.
-        private async Task<IDictionary<string, CdmEntity>> InitCdmEntitiesDictAsync(CancellationToken cancellationToken)
+        internal async Task<IDictionary<string, CdmEntity>> InitCdmEntitiesDictAsync(CancellationToken cancellationToken)
         {
             log.LogInformation("Loading CDM entities.");
 

--- a/src/DataverseToSql/DataverseToSql.Core/EnvironmentConfiguration.cs
+++ b/src/DataverseToSql/DataverseToSql.Core/EnvironmentConfiguration.cs
@@ -84,6 +84,8 @@ namespace DataverseToSql.Core
         // Configuration of the ingestion process
         public IngestionConfiguration Ingestion { get; set; } = new();
 
+        public SchemaHandlingConfiguration SchemaHandling { get; set; } = new();
+
         // Fill the configuration with placeholder values.
         // Useful to generate a template.
         internal void FillTemplateValues()
@@ -93,6 +95,7 @@ namespace DataverseToSql.Core
             ConfigurationStorage.FillTemplateValues();
             Database.FillTemplateValues();
             SynapseWorkspace.FillTemplateValues();
+            SchemaHandling.FillTemplateValues();
         }
     }
 
@@ -175,6 +178,16 @@ namespace DataverseToSql.Core
             SubscriptionId = "<Subscription ID of the Synapse workspace>";
             ResourceGroup = "<Resource Group of the Synapse workspace>";
             Workspace = "<Name of the Synapse workspace>";
+        }
+    }
+
+    public class SchemaHandlingConfiguration
+    {
+        public bool EnableSchemaUpgradeForExistingTables { get; set; } = true;
+
+        internal void FillTemplateValues()
+        {
+            EnableSchemaUpgradeForExistingTables = true;
         }
     }
 }


### PR DESCRIPTION
Introduced EnableSchemaUpgradeForExistingTables to control whether schema changes must be propagated to existing tables.
Closes #3 