### PR TITLE
Aligned schema of Optionset tables to DES

### DIFF
--- a/src/DataverseToSql/DataverseToSql.Core/SqlObjects/Optionsets_GlobalOptionsetMetadata.sql
+++ b/src/DataverseToSql/DataverseToSql.Core/SqlObjects/Optionsets_GlobalOptionsetMetadata.sql
@@ -2,24 +2,24 @@
 -- Licensed under the MIT License.
 
 CREATE TABLE [$$SCHEMA$$].[GlobalOptionsetMetadata] (
-	[OptionSetName] [varchar](128) NULL,
-	[Option] [bigint] NULL,
-	[IsUserLocalizedLabel] [varchar](6) NULL,
-	[LocalizedLabelLanguageCode] [bigint] NULL,
-	[LocalizedLabel] [varchar](700) NULL,
-	[GlobalOptionSetName] [varchar](128) NULL,
-	[EntityName] [varchar](128) NULL
+	[OptionSetName] [nvarchar](64) NULL,
+	[Option] [int] NULL,
+	[IsUserLocalizedLabel] [bit] NULL,
+	[LocalizedLabelLanguageCode] [int] NULL,
+	[LocalizedLabel] [nvarchar](350) NULL,
+	[GlobalOptionSetName] [nvarchar](64) NULL,
+	[EntityName] [nvarchar](64) NULL
 );
 GO
 
 CREATE TYPE [DataverseToSql].[GlobalOptionsetMetadata_TableType] AS TABLE (
-	[OptionSetName] [varchar](128) NULL,
-	[Option] [bigint] NULL,
-	[IsUserLocalizedLabel] [varchar](6) NULL,
-	[LocalizedLabelLanguageCode] [bigint] NULL,
-	[LocalizedLabel] [varchar](700) NULL,
-	[GlobalOptionSetName] [varchar](128) NULL,
-	[EntityName] [varchar](128) NULL
+	[OptionSetName] [nvarchar](64) NULL,
+	[Option] [int] NULL,
+	[IsUserLocalizedLabel] [bit] NULL,
+	[LocalizedLabelLanguageCode] [int] NULL,
+	[LocalizedLabel] [nvarchar](350) NULL,
+	[GlobalOptionSetName] [nvarchar](64) NULL,
+	[EntityName] [nvarchar](64) NULL
 );
 GO
 

--- a/src/DataverseToSql/DataverseToSql.Core/SqlObjects/Optionsets_OptionsetMetadata.sql
+++ b/src/DataverseToSql/DataverseToSql.Core/SqlObjects/Optionsets_OptionsetMetadata.sql
@@ -2,22 +2,22 @@
 -- Licensed under the MIT License.
 
 CREATE TABLE [$$SCHEMA$$].[OptionsetMetadata] (
-	[EntityName] [varchar](128) NULL,
-	[OptionSetName] [varchar](128)  NULL,
-	[Option] [bigint] NULL,
-	[IsUserLocalizedLabel] [varchar](6) NULL,
-	[LocalizedLabelLanguageCode] [bigint] NULL,
-	[LocalizedLabel] [varchar](700)  NULL
+	[EntityName] [nvarchar](64) NULL,
+	[OptionSetName] [nvarchar](64)  NULL,
+	[Option] [int] NULL,
+	[IsUserLocalizedLabel] [bit] NULL,
+	[LocalizedLabelLanguageCode] [int] NULL,
+	[LocalizedLabel] [nvarchar](350)  NULL
 );
 GO
 
 CREATE TYPE [DataverseToSql].[OptionsetMetadata_TableType] AS TABLE (
-	[EntityName] [varchar](128) NULL,
-	[OptionSetName] [varchar](128)  NULL,
-	[Option] [bigint] NULL,
-	[IsUserLocalizedLabel] [varchar](6) NULL,
-	[LocalizedLabelLanguageCode] [bigint] NULL,
-	[LocalizedLabel] [varchar](700)  NULL
+	[EntityName] [nvarchar](64) NULL,
+	[OptionSetName] [nvarchar](64)  NULL,
+	[Option] [int] NULL,
+	[IsUserLocalizedLabel] [bit] NULL,
+	[LocalizedLabelLanguageCode] [int] NULL,
+	[LocalizedLabel] [nvarchar](350)  NULL
 );
 GO
 

--- a/src/DataverseToSql/DataverseToSql.Core/SqlObjects/Optionsets_StateMetadata.sql
+++ b/src/DataverseToSql/DataverseToSql.Core/SqlObjects/Optionsets_StateMetadata.sql
@@ -2,20 +2,20 @@
 -- Licensed under the MIT License.
 
 CREATE TABLE [$$SCHEMA$$].[StateMetadata] (
-	[EntityName] [varchar](128) NULL,
-	[State] [bigint] NULL,
-	[IsUserLocalizedLabel] [varchar](6) NULL,
-	[LocalizedLabelLanguageCode] [bigint] NULL,
-	[LocalizedLabel] [varchar](700) NULL
+	[EntityName] [nvarchar](64) NULL,
+	[State] [int] NULL,
+	[IsUserLocalizedLabel] [bit] NULL,
+	[LocalizedLabelLanguageCode] [int] NULL,
+	[LocalizedLabel] [nvarchar](350) NULL
 );
 GO
 
 CREATE TYPE [DataverseToSql].[StateMetadata_TableType] AS TABLE (
-	[EntityName] [varchar](128) NULL,
-	[State] [bigint] NULL,
-	[IsUserLocalizedLabel] [varchar](6) NULL,
-	[LocalizedLabelLanguageCode] [bigint] NULL,
-	[LocalizedLabel] [varchar](700) NULL
+	[EntityName] [nvarchar](64) NULL,
+	[State] [int] NULL,
+	[IsUserLocalizedLabel] [bit] NULL,
+	[LocalizedLabelLanguageCode] [int] NULL,
+	[LocalizedLabel] [nvarchar](350) NULL
 );
 GO
 

--- a/src/DataverseToSql/DataverseToSql.Core/SqlObjects/Optionsets_StatusMetadata.sql
+++ b/src/DataverseToSql/DataverseToSql.Core/SqlObjects/Optionsets_StatusMetadata.sql
@@ -2,22 +2,22 @@
 -- Licensed under the MIT License.
 
 CREATE TABLE [$$SCHEMA$$].[StatusMetadata] (
-	[EntityName] [varchar](128) NULL,
-	[State] [bigint] NULL,
-	[Status] [bigint] NULL,
-	[IsUserLocalizedLabel] [varchar](6) NULL,
-	[LocalizedLabelLanguageCode] [bigint] NULL,
-	[LocalizedLabel] [varchar](700) NULL
+	[EntityName] [nvarchar](64) NULL,
+	[State] [int] NULL,
+	[Status] [int] NULL,
+	[IsUserLocalizedLabel] [bit] NULL,
+	[LocalizedLabelLanguageCode] [int] NULL,
+	[LocalizedLabel] [nvarchar](350) NULL
 );
 GO
 
 CREATE TYPE [DataverseToSql].[StatusMetadata_TableType] AS TABLE (
-	[EntityName] [varchar](128) NULL,
-	[State] [bigint] NULL,
-	[Status] [bigint] NULL,
-	[IsUserLocalizedLabel] [varchar](6) NULL,
-	[LocalizedLabelLanguageCode] [bigint] NULL,
-	[LocalizedLabel] [varchar](700) NULL
+	[EntityName] [nvarchar](64) NULL,
+	[State] [int] NULL,
+	[Status] [int] NULL,
+	[IsUserLocalizedLabel] [bit] NULL,
+	[LocalizedLabelLanguageCode] [int] NULL,
+	[LocalizedLabel] [nvarchar](350) NULL
 );
 GO
 

--- a/src/DataverseToSql/DataverseToSql.Core/SqlObjects/Optionsets_TargetMetadata.sql
+++ b/src/DataverseToSql/DataverseToSql.Core/SqlObjects/Optionsets_TargetMetadata.sql
@@ -2,18 +2,18 @@
 -- Licensed under the MIT License.
 
 CREATE TABLE [$$SCHEMA$$].[TargetMetadata] (
-	[EntityName] [varchar](128) NULL,
-	[AttributeName] [varchar](128) NULL,
-	[ReferencedEntity] [varchar](128) NULL,
-	[ReferencedAttribute] [varchar](128) NULL
+	[EntityName] [nvarchar](64) NULL,
+	[AttributeName] [nvarchar](64) NULL,
+	[ReferencedEntity] [nvarchar](64) NULL,
+	[ReferencedAttribute] [nvarchar](64) NULL
 );
 GO
 
 CREATE TYPE [DataverseToSql].[TargetMetadata_TableType] AS TABLE (
-	[EntityName] [varchar](128) NULL,
-	[AttributeName] [varchar](128) NULL,
-	[ReferencedEntity] [varchar](128) NULL,
-	[ReferencedAttribute] [varchar](128) NULL
+	[EntityName] [nvarchar](64) NULL,
+	[AttributeName] [nvarchar](64) NULL,
+	[ReferencedEntity] [nvarchar](64) NULL,
+	[ReferencedAttribute] [nvarchar](64) NULL
 );
 GO
 


### PR DESCRIPTION
BREAKING CHANGE: the data type of columns in Optionset tables (GlobalOptionsetMetadata, OptionsetMetadata, StateMetadata, StatusMetadata, TargetMetadata) has been aligned to the schema originally produced by DES. varchar columns are now nvarchar and their length has been reduced in half. IsUserLocalizedLabel is now a bit instead of varchar(5).
Processes that rely on the previous schema may fail and must modified to use the new schema.
Fixed #42 